### PR TITLE
Implement basic taskflow worker

### DIFF
--- a/craton/_i18n.py
+++ b/craton/_i18n.py
@@ -1,0 +1,41 @@
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+"""oslo.i18n integration module.
+
+See http://docs.openstack.org/developer/oslo.i18n/usage.html
+
+"""
+
+import oslo_i18n
+
+
+_translators = oslo_i18n.TranslatorFactory(domain='craton')
+
+# The primary translation function using the well-known name "_"
+_ = _translators.primary
+
+# The contextual translation function using the name "_C"
+_C = _translators.contextual_form
+
+# The plural translation function using the name "_P"
+_P = _translators.plural_form
+
+# Translators for log levels.
+#
+# The abbreviated names are meant to reflect the usual use of a short
+# name like '_'. The "L" is for "log" and the other letter comes from
+# the level.
+_LI = _translators.log_info
+_LW = _translators.log_warning
+_LE = _translators.log_error
+_LC = _translators.log_critical

--- a/craton/_i18n.py
+++ b/craton/_i18n.py
@@ -1,15 +1,3 @@
-#    Licensed under the Apache License, Version 2.0 (the "License"); you may
-#    not use this file except in compliance with the License. You may obtain
-#    a copy of the License at
-#
-#         http://www.apache.org/licenses/LICENSE-2.0
-#
-#    Unless required by applicable law or agreed to in writing, software
-#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-#    License for the specific language governing permissions and limitations
-#    under the License.
-
 """oslo.i18n integration module.
 
 See http://docs.openstack.org/developer/oslo.i18n/usage.html

--- a/craton/cmd/worker.py
+++ b/craton/cmd/worker.py
@@ -1,0 +1,96 @@
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import contextlib
+import signal
+import sys
+
+from oslo_config import cfg
+from oslo_log import log as logging
+from oslo_utils import uuidutils
+from stevedore import driver
+from taskflow import engines
+from taskflow.persistence import models
+
+from craton.workflow import worker
+
+LOG = logging.getLogger(__name__)
+CONF = cfg.CONF
+
+
+# This needs to be a globally accessible (ie: top-level) function, so
+# flow recovery can execute it to re-create the intended workflows.
+def workflow_factory(name, *args, **kwargs):
+    mgr = driver.DriverManager(
+        namespace='craton.workflow', name=name,
+        invoke_on_load=True, invoke_args=args, invoke_kwds=kwargs)
+    return mgr.driver.workflow()
+
+
+def main():
+    logging.register_options(CONF)
+    CONF(sys.argv[1:], project='craton-worker', default_config_files=[])
+    logging.setup(CONF, 'craton')
+
+    persistence, board, conductor = worker.start(CONF)
+
+    def stop(signum, _frame):
+        LOG.info('Caught signal %s, gracefully exiting', signum)
+        conductor.stop()
+    signal.signal(signal.SIGTERM, stop)
+
+    # TODO(gus): eventually feeding in jobs will happen elsewhere and
+    # main() will end here.
+    #
+    # conductor.wait()
+    # sys.exit(0)
+
+    def make_save_book(persistence, job_id,
+                       flow_plugin, plugin_args=(), plugin_kwds={}):
+        flow_id = book_id = job_id  # Do these need to be different?
+        book = models.LogBook(book_id)
+        detail = models.FlowDetail(flow_id, uuidutils.generate_uuid())
+        book.add(detail)
+
+        factory_args = [flow_plugin] + list(plugin_args)
+        factory_kwargs = plugin_kwds
+        engines.save_factory_details(detail, workflow_factory,
+                                     factory_args, factory_kwargs)
+        with contextlib.closing(persistence.get_connection()) as conn:
+            conn.save_logbook(book)
+            return book
+
+    # Feed in example task
+    job_uuid = uuidutils.generate_uuid()
+    LOG.debug('Posting job %s', job_uuid)
+    details = {
+        'store': {
+            'foo': 'bar',
+        },
+    }
+
+    job = board.post(
+        job_uuid,
+        book=make_save_book(
+            persistence, job_uuid,
+            'testflow', plugin_kwds=dict(task_delay=2)),
+        details=details)
+
+    # Run forever.  TODO(gus): This is what we want to do in production
+    # conductor.wait()
+    job.wait()
+    LOG.debug('Job finished: %s', job.state)
+    conductor.stop()
+
+
+if __name__ == '__main__':
+    main()

--- a/craton/cmd/worker.py
+++ b/craton/cmd/worker.py
@@ -1,15 +1,3 @@
-#    Licensed under the Apache License, Version 2.0 (the "License"); you may
-#    not use this file except in compliance with the License. You may obtain
-#    a copy of the License at
-#
-#         http://www.apache.org/licenses/LICENSE-2.0
-#
-#    Unless required by applicable law or agreed to in writing, software
-#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-#    License for the specific language governing permissions and limitations
-#    under the License.
-
 import contextlib
 import signal
 import sys

--- a/craton/workflow/base.py
+++ b/craton/workflow/base.py
@@ -1,15 +1,3 @@
-#    Licensed under the Apache License, Version 2.0 (the "License"); you may
-#    not use this file except in compliance with the License. You may obtain
-#    a copy of the License at
-#
-#         http://www.apache.org/licenses/LICENSE-2.0
-#
-#    Unless required by applicable law or agreed to in writing, software
-#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-#    License for the specific language governing permissions and limitations
-#    under the License.
-
 import abc
 
 import six

--- a/craton/workflow/base.py
+++ b/craton/workflow/base.py
@@ -1,0 +1,26 @@
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import abc
+
+import six
+
+
+@six.add_metaclass(abc.ABCMeta)
+class WorkflowFactory(object):
+
+    @abc.abstractmethod
+    def workflow(self):
+        """Construct appropriate taskflow flow object.
+
+        :returns: A flow.Flow subclass
+        """

--- a/craton/workflow/testflow.py
+++ b/craton/workflow/testflow.py
@@ -1,15 +1,3 @@
-#    Licensed under the Apache License, Version 2.0 (the "License"); you may
-#    not use this file except in compliance with the License. You may obtain
-#    a copy of the License at
-#
-#         http://www.apache.org/licenses/LICENSE-2.0
-#
-#    Unless required by applicable law or agreed to in writing, software
-#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-#    License for the specific language governing permissions and limitations
-#    under the License.
-
 import time
 
 from oslo_log import log as logging

--- a/craton/workflow/testflow.py
+++ b/craton/workflow/testflow.py
@@ -1,0 +1,52 @@
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import time
+
+from oslo_log import log as logging
+from taskflow import task
+from taskflow.patterns import linear_flow
+
+from craton.workflow import base
+
+LOG = logging.getLogger(__name__)
+
+
+class Sleep(task.Task):
+    def __init__(self, delay=10, **kwargs):
+        super(Sleep, self).__init__(**kwargs)
+        self.delay = delay
+
+    def execute(self):
+        LOG.info('Doing task %s', self)
+        time.sleep(self.delay)
+
+
+class Fail(task.Task):
+    def execute(self):
+        LOG.info('Failing task %s', self)
+        raise RuntimeError('failure in task %s' % self)
+
+
+class TestFlow(base.WorkflowFactory):
+    def __init__(self, task_delay=5):
+        super(TestFlow, self).__init__()
+        self.task_delay = task_delay
+
+    def workflow(self):
+        f = linear_flow.Flow('example')
+        f.add(
+            Sleep(name='step 1', delay=self.task_delay),
+            Sleep(name='step 2', delay=self.task_delay),
+            Fail(name='step 3'),
+        )
+        return f

--- a/craton/workflow/worker.py
+++ b/craton/workflow/worker.py
@@ -1,0 +1,88 @@
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import contextlib
+import threading
+
+from oslo_config import cfg
+from oslo_log import log as logging
+from oslo_utils import uuidutils
+from taskflow.conductors import backends as conductors
+from taskflow.jobs import backends as boards
+from taskflow.persistence import backends as persistence_backends
+from zake import fake_client
+
+from craton._i18n import _LI
+
+
+LOG = logging.getLogger(__name__)
+CONF = cfg.CONF
+
+OPTS = [
+    cfg.StrOpt('job_board_name', default='craton_jobs',
+               help='Name of job board used to store outstanding jobs.'),
+    cfg.IntOpt('max_simultaneous_jobs', default=9,
+               help='Number of tasks to run in parallel on this worker.'),
+]
+CONF.register_opts(OPTS)
+
+TASKFLOW_OPTS = [
+    cfg.StrOpt('connection', default='memory',
+               help='Taskflow backend used for persisting taskstate.'),
+    cfg.StrOpt('job_board_url',
+               default='zookeeper://localhost?path=/taskflow/craton/jobs',
+               help='URL used to store outstanding jobs'),
+    cfg.BoolOpt('db_upgrade', default=True,
+                help='Upgrade DB schema on startup.'),
+]
+CONF.register_opts(TASKFLOW_OPTS, group='taskflow')
+
+
+def _get_persistence_backend(conf):
+    return persistence_backends.fetch({
+        'connection': conf.taskflow.connection,
+    })
+
+
+def _get_jobboard_backend(conf, persistence=None):
+    client = None
+    if conf.taskflow.connection == 'memory':
+        client = fake_client.FakeClient()
+    return boards.fetch(conf.job_board_name,
+                        {'board': conf.taskflow.job_board_url},
+                        client=client, persistence=persistence)
+
+
+def start(conf):
+    persistence = _get_persistence_backend(conf)
+
+    if conf.taskflow.db_upgrade:
+        with contextlib.closing(persistence.get_connection()) as conn:
+            LOG.info(_LI('Checking for database schema upgrade'))
+            conn.upgrade()
+
+    my_name = uuidutils.generate_uuid()
+    LOG.info(_LI('I am %s'), my_name)
+
+    board = _get_jobboard_backend(conf, persistence=persistence)
+
+    conductor = conductors.fetch(
+        'nonblocking', my_name, board,
+        engine='parallel',
+        max_simultaneous_jobs=conf.max_simultaneous_jobs,
+        persistence=persistence)
+
+    board.connect()
+    LOG.debug('Starting taskflow conductor loop')
+    threading.Thread(target=conductor.run).start()
+
+    return persistence, board, conductor

--- a/craton/workflow/worker.py
+++ b/craton/workflow/worker.py
@@ -1,15 +1,3 @@
-#    Licensed under the Apache License, Version 2.0 (the "License"); you may
-#    not use this file except in compliance with the License. You may obtain
-#    a copy of the License at
-#
-#         http://www.apache.org/licenses/LICENSE-2.0
-#
-#    Unless required by applicable law or agreed to in writing, software
-#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-#    License for the specific language governing permissions and limitations
-#    under the License.
-
 import contextlib
 import threading
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,14 +6,21 @@ Flask
 flask_restful
 ipaddress>=1.0.7;python_version<'3.3'  # PSF
 jsonschema>=2.0.0,<3.0.0,!=2.5.0  # MIT
-oslo.db>=4.1.0 
+kazoo>=2.2 # Apache-2.0
+oslo.db>=4.1.0
+oslo.i18n>=2.1.0 # Apache-2.0
 oslo.middleware>=3.0.0 # Apache-2.0
 oslo.context>=2.2.0 # Apache-2.0
 oslo.config>=3.9.0 # Apache-2.0
 oslo.log>=1.14.0 # Apache-2.0
 oslo.serialization>=1.10.0 # Apache-2.0
+oslo.utils>=3.5.0 # Apache-2.0
 PasteDeploy>=1.5.0 # MIT
 Paste # MIT
 pbr>=1.6
+six>=1.9.0 # MIT
 SQLAlchemy>=1.0.10,<1.1.0  # MIT
 sqlalchemy-utils  # BSD License
+stevedore>=1.5.0 # Apache-2.0
+taskflow>=1.26.0 # Apache-2.0
+zake>=0.1.6 # Apache-2.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,6 +23,13 @@ classifier =
 packages =
     craton
 
+[entry_points]
+console_scripts =
+    craton-worker = craton.cmd.worker:main
+
+craton.workflow =
+    testflow = craton.workflow.testflow:TestFlow
+
 [build_sphinx]
 source-dir = doc/source
 build-dir = doc/build


### PR DESCRIPTION
A taskflow worker process, that runs flows from a persistent job board
in a parallel thread worker pool.  Tasks are defined through stevedore
plugins in the 'craton.workflow' namespace - see the TestFlow example.

Defaults are set to use an in-memory fake "persistent storage", for ease
of testing.  We will want to change this default at some point in the
future.

Also, the worker main() is currently hardcoded to feed in a single
TestFlow job.  Again, we will want to add a command-line tool and/or web
interface to post jobs once we have an out-of-process job board.