### PR TITLE
Use semantic reStructuredText for CLI docs

### DIFF
--- a/doc/source/cratoncli.rst
+++ b/doc/source/cratoncli.rst
@@ -1,12 +1,13 @@
-..
 
 ==================================
 Craton service command-line client
 ==================================
 
+.. program:: craton
 
 Contents
 ^^^^^^^^
+
 `craton usage`_
 
 `craton optional arguments`_
@@ -63,568 +64,836 @@ Contents
 
 `craton user-list`_
 
+
 craton usage
 ------------
 
 **Subcommands:**
 
-**craton usage**
+:program:`craton usage`
     Show usages of craton client.
-**craton project-create**
+
+:program:`craton project-create`
     Create a new project.
-**craton project-delete**
+
+:program:`craton project-delete`
     Delete a project.
-**craton project-list**
+
+:program:`craton project-list`
     List all projects.
-**craton project-show**
+
+:program:`craton project-show`
     Show detailed information about a project.
-**craton project-update**
+
+:program:`craton project-update`
     Update information about a project.
-**craton region-create**
+
+:program:`craton region-create`
     Create a new region.
-**craton region-delete**
+
+:program:`craton region-delete`
     Delete a region.
-**craton region-list**
+
+:program:`craton region-list`
     List all regions.
-**craton region-show**
+
+:program:`craton region-show`
     Show detailed information about a region.
-**craton region-update**
+
+:program:`craton region-update`
     Update information about a region.
-**craton cell-create**
+
+:program:`craton cell-create`
     Create a new cell.
-**craton cell-delete**
+
+:program:`craton cell-delete`
     Delete a cell.
-**craton cell-list**
+
+:program:`craton cell-list`
     List all cells.
-**craton cell-show**
+
+:program:`craton cell-show`
     Show detailed information about a cell.
-**craton cell-update**
+
+:program:`craton cell-update`
     Update information about a cell.
-**craton device-create**
+
+:program:`craton device-create`
     Create a new device.
-**craton device-delete**
+
+:program:`craton device-delete`
     Delete a device.
-**craton device-list**
+
+:program:`craton device-list`
     List all devices.
-**craton device-show**
+
+:program:`craton device-show`
     Show detailed information about a device.
-**craton device-update**
+
+:program:`craton device-update`
     Update information about a device.
-**craton host-create**
+
+:program:`craton host-create`
     Create a new host.
-**craton host-delete**
+
+:program:`craton host-delete`
     Delete a host.
-**craton host-list**
+
+:program:`craton host-list`
     List all hosts.
-**craton host-show**
+
+:program:`craton host-show`
     Show detailed information about a host.
-**craton host-update**
+
+:program:`craton host-update`
     Update information about a host.
-**craton user-list**
+
+:program:`craton user-list`
     List the users of a project.
-**craton help**
+
+:program:`craton help`
     Display help about this program or one of its subcommands.
+
 
 craton optional arguments
 -------------------------
 
-``--version``
- Show program's version number and exit.
-``-v, --verbose``
- Print more verbose output.
+.. option:: --version
+
+    Show program's version number and exit.
+
+.. option:: -v, --verbose
+
+    Print more verbose output.
 
 craton project-create
 ---------------------
+
+.. program:: craton project-create
+
 Create a new project.
+
 ::
 
- usage: craton project-create [-n <name>] [-u <uuid>]
+    usage: craton project-create [-n <name>] [-u <uuid>]
 
 **Optional arguments:**
 
-``-n <name>, --name <name>``
- Name of the project.
+.. option:: -n <name>, --name <name>
 
-``-u <uuid>, --uuid <uuid>``
- UUID of the project.
+    Name of the project.
+
+.. option:: -u <uuid>, --uuid <uuid>
+
+    UUID of the project.
 
 
 craton project-delete
 ---------------------
+
+.. program:: craton project-delete
+
 Delete a project.
+
 ::
 
- usage: craton project-delete <project>
+    usage: craton project-delete <project>
 
 **Positional arguments:**
 
-``<project>``
- UUID of the project.
+.. option:: project
+
+    UUID of the project.
+
 
 craton project-list
 -------------------
+
+.. program:: craton project-list
+
 List the projects.
+
 ::
 
- usage: craton project-list [--detail] [--limit <limit>]
+    usage: craton project-list [--detail] [--limit <limit>]
 
 **Optional arguments:**
 
-``--detail``
- Show detailed information about the projects.
-``--limit <limit>``
- Maximum number of projects to return per request, 0 for no limit. Default is the maximum number used by the Craton API Service.
+.. option:: --detail
+
+    Show detailed information about the projects.
+
+.. option:: --limit <limit>
+
+    Maximum number of projects to return per request, 0 for no limit. Default
+    is the maximum number used by the Craton API Service.
+
 
 craton project-show
 -------------------
+
+.. program:: craton project-show
+
 Show detailed information about a project.
+
 ::
 
- usage: craton project-show <project>
+    usage: craton project-show <project>
 
 **Positional arguments:**
 
-``<project>``
- UUID of the project.
+.. option:: project
+
+    UUID of the project.
 
 
 craton project-update
 ---------------------
+
+.. program:: craton project-update
+
 Update information about a project.
+
 ::
 
- usage: craton project-update <project> [-n <name>]
+    usage: craton project-update <project> [-n <name>]
 
 **Positional arguments:**
 
-``<project>``
- UUID of the project.
+.. option:: project
+
+    UUID of the project.
 
 **Optional arguments:**
 
-``-n <name>, --name <name>``
- New name for the project.
+.. option:: -n <name>, --name <name>
+
+    New name for the project.
 
 craton region-create
 --------------------
+
+.. program:: craton region-create
+
 Create a new region.
+
 ::
 
- usage: craton region-create [-n <name>] [-u <uuid>] [-p <project>] [--note <note>]
+    usage: craton region-create [-n <name>]
+                                [-u <uuid>]
+                                [-p <project>]
+                                [--note <note>]
 
 **Optional arguments:**
 
-``-n <name>, --name <name>``
- Name of the region.
+.. option:: -n <name>, --name <name>
 
-``-u <uuid>, --uuid <uuid>``
- UUID of the region.
+    Name of the region.
 
-``-p <project>, --project <project>, --project_uuid <project>``
- UUID of the project that this region belongs to.
+.. option:: -u <uuid>, --uuid <uuid>
 
-``--note <note>``
- Note about the region.
+    UUID of the region.
+
+.. option:: -p <project>, --project <project>, --project_uuid <project>
+
+    UUID of the project that this region belongs to.
+
+.. option:: --note <note>
+
+    Note about the region.
+
 
 craton region-delete
 --------------------
+
+.. program:: craton region-delete
+
 Delete a region.
+
 ::
 
- usage: craton region-delete <region>
+    usage: craton region-delete <region>
 
 **Positional arguments:**
 
-``<region>``
- UUID of the region.
+.. option:: region
+
+    UUID of the region.
 
 craton region-list
 ------------------
+
+.. program:: craton region-list
+
 List the regions.
+
 ::
 
- usage: craton region-list [--detail] [--limit <limit>]
-                           [--sort-key <field>] [--sort-dir <direction>]
-                           [--fields <field> [<field> ...]]
+    usage: craton region-list [--detail] [--limit <limit>]
+                              [--sort-key <field>] [--sort-dir <direction>]
+                              [--fields <field> [<field> ...]]
 
 **Optional arguments:**
 
-``--detail``
- Show detailed information about the regions.
+.. option:: --detail
 
-``--limit <limit>``
- Maximum number of regions to return per request, 0 for no limit. Default is the maximum number used by the Craton API Service.
+    Show detailed information about the regions.
 
-``--sort-key <field>``
- Region field that will be used for sorting.
+.. option:: --limit <limit>
 
-``--sort-dir <direction>``
- Sort direction: “asc” (the default) or “desc”.
+    Maximum number of regions to return per request, 0 for no limit. Default
+    is the maximum number used by the Craton API Service.
 
-``--fields <field> [<field> ...]``
- One or more region fields. Only these fields will be fetched from the server. Can not be used when ‘-- detail’ is specified.
+.. option:: --sort-key <field>
+
+    Region field that will be used for sorting.
+
+.. option:: --sort-dir <direction>
+
+    Sort direction: “asc” (the default) or “desc”.
+
+.. option:: --fields <field> [<field> ...]
+
+    One or more region fields. Only these fields will be fetched from the
+    server.  Can not be used when ‘-- detail’ is specified.
 
 craton region-show
 ------------------
+
+.. program:: craton region-show
+
 Show detailed information about a region.
+
 ::
 
- usage: craton region-show <region>
+    usage: craton region-show <region>
 
 **Positional arguments:**
 
-``<region>``
- UUID of the region.
+.. option:: region
+
+    UUID of the region.
 
 craton region-update
 --------------------
+
+.. program:: craton region-update
+
 Update information about a region.
+
 ::
 
- usage: craton region-update <region> [-n <name>]
+    usage: craton region-update <region> [-n <name>]
 
 **Positional arguments:**
 
-``<region>``
- UUID of the region.
+.. option:: region
+
+    UUID of the region.
 
 **Optional arguments:**
 
-``-n <name>, --name <name>``
- New name for the region.
+.. option:: -n <name>, --name <name>
+
+    New name for the region.
+
 
 craton cell-create
 ------------------
+
+.. program:: craton cell-create
+
 Create a new cell.
+
 ::
 
- usage: craton cell-create [-n <name>] [-u <uuid>] [-p <project>] [-r <region>] [--note <note>]
+    usage: craton cell-create [-n <name>]
+                            [-u <uuid>]
+                            [-p <project>]
+                            [-r <region>]
+                            [--note <note>]
 
 **Optional arguments:**
 
-``-n <name>, --name <name>``
- Name of the cell.
+.. option:: -n <name>, --name <name>
 
-``-u <uuid>, --uuid <uuid>``
- UUID of the cell.
+    Name of the cell.
 
-``-p <project>, --project <project>, --project_uuid <project>``
- UUID of the project that this cell belongs to.
+.. option:: -u <uuid>, --uuid <uuid>
 
-``-r <region>, --region <region>, --region_uuid <region>``
- UUID of the region that this cell belongs to.
+    UUID of the cell.
 
-``--note <note>``
- Note about the cell.
+.. option:: -p <project>, --project <project>, --project_uuid <project>
+
+    UUID of the project that this cell belongs to.
+
+.. option:: -r <region>, --region <region>, --region_uuid <region>
+
+    UUID of the region that this cell belongs to.
+
+.. option:: --note <note>
+
+    Note about the cell.
+
 
 craton cell-delete
 ------------------
+
+.. program:: craton cell-delete
+
 Delete a cell.
+
 ::
 
- usage: craton cell-delete <cell>
+    usage: craton cell-delete <cell>
 
 **Positional arguments:**
 
-``<cell>``
- UUID of the cell.
+.. option:: cell
+
+    UUID of the cell.
+
 
 craton cell-list
 ----------------
+
+.. program:: craton cell-list
+
 List the cells.
+
 ::
 
- usage: craton cell-list [--detail] [--limit <limit>]
-                         [--sort-key <field>] [--sort-dir <direction>]
-                         [--fields <field> [<field> ...]]
-                         [--region <region>]
+    usage: craton cell-list [--detail] [--limit <limit>]
+                            [--sort-key <field>] [--sort-dir <direction>]
+                            [--fields <field> [<field> ...]]
+                            [--region <region>]
 
 **Optional arguments:**
 
-``--detail``
- Show detailed information about the cells.
+.. option:: --detail
 
-``-r <region>, --region <region>``
- UUID of the region that contains the desired list of cells.
+    Show detailed information about the cells.
 
-``--limit <limit>``
- Maximum number of cells to return per request, 0 for no limit. Default is the maximum number used by the Craton API Service.
+.. option:: -r <region>, --region <region>
 
-``--sort-key <field>``
- Cell field that will be used for sorting.
+    UUID of the region that contains the desired list of cells.
 
-``--sort-dir <direction>``
- Sort direction: “asc” (the default) or “desc”.
+.. option:: --limit <limit>
 
-``--fields <field> [<field> ...]``
- One or more cell fields. Only these fields will be fetched from the server. Can not be used when ‘-- detail’ is specified.
+    Maximum number of cells to return per request, 0 for no limit. Default is
+    the maximum number used by the Craton API Service.
+
+.. option:: --sort-key <field>
+
+    Cell field that will be used for sorting.
+
+.. option:: --sort-dir <direction>
+
+    Sort direction: “asc” (the default) or “desc”.
+
+.. option:: --fields <field> [<field> ...]
+
+    One or more cell fields. Only these fields will be fetched from the
+    server.  Can not be used when ‘-- detail’ is specified.
+
 
 craton cell-show
 ----------------
+
+.. program:: craton cell-show
+
 Show detailed information about a cell.
+
 ::
 
- usage: craton cell-show <cell>
+    usage: craton cell-show <cell>
 
 **Positional arguments:**
 
-``<cell>``
- UUID of the cell.
+.. option:: cell
+
+    UUID of the cell.
+
 
 craton cell-update
 ------------------
+
+.. program:: craton cell-update
+
 Update information about a cell.
+
 ::
 
- usage: craton cell-update <cell> [-n <name>]
+    usage: craton cell-update <cell> [-n <name>]
 
 **Positional arguments:**
 
-``<cell>``
- UUID of the cell.
+.. option:: cell
+
+    UUID of the cell.
 
 **Optional arguments:**
 
-``-n <name>, --name <name>``
- New name for the cell.
+.. option:: -n <name>, --name <name>
+
+    New name for the cell.
+
 
 craton device-create
 --------------------
+
+.. program:: craton device-create
+
 Create a new device.
+
 ::
 
- usage: craton device-create [-n <name>] [-t <type>] [-a <active>] [-u <uuid>] [-p <project>] [-r <region>] [-c <cell>] [--note <note>]
+    usage: craton device-create [-n <name>]
+                            [-t <type>]
+                            [-a <active>]
+                            [-u <uuid>]
+                            [-p <project>]
+                            [-r <region>]
+                            [-c <cell>]
+                            [--note <note>]
 
 **Optional arguments:**
 
-``-n <name>, --name <name>``
- Name of the device.
+.. option:: -n <name>, --name <name>
 
-``-t <type>, --type <type>``
- Type of device.
+    Name of the device.
 
-``-a <active>, --active <active>``
- Active or inactive state for a device: ‘true’ or ‘false’.
+.. option:: -t <type>, --type <type>
 
-``-u <uuid>, --uuid <uuid>``
- UUID of the device.
+    Type of device.
 
-``-p <project>, --project <project>, --project_uuid <project>``
- UUID of the project that this device belongs to.
+.. option:: -a <active>, --active <active>
 
-``-r <region>, --region <region>, --region_uuid <region>``
- UUID of the region that this device belongs to.
+    Active or inactive state for a device: ‘true’ or ‘false’.
 
-``-c <cell>, --cell <cell>, --cell_uuid <cell>``
- UUID of the cell that this device belongs to.
+.. option:: -u <uuid>, --uuid <uuid>
 
-``--note <note>``
- Note about the device.
+    UUID of the device.
+
+.. option:: -p <project>, --project <project>, --project_uuid <project>
+
+    UUID of the project that this device belongs to.
+
+.. option:: -r <region>, --region <region>, --region_uuid <region>
+
+    UUID of the region that this device belongs to.
+
+.. option:: -c <cell>, --cell <cell>, --cell_uuid <cell>
+
+    UUID of the cell that this device belongs to.
+
+.. option:: --note <note>
+
+    Note about the device.
+
 
 craton device-delete
 --------------------
+
+.. program:: craton device-delete
+
 Delete a device.
+
 ::
 
- usage: craton device-delete <device>
+    usage: craton device-delete <device>
 
 **Positional arguments:**
 
-``<device>``
- UUID of the device.
+.. option:: device
+
+    UUID of the device.
+
 
 craton device-list
 ------------------
+
+.. program:: craton device-list
+
 List the devices.
+
 ::
 
- usage: craton device-list [--detail] [--limit <limit>]
-                           [--sort-key <field>] [--sort-dir <direction>]
-                           [--fields <field> [<field> ...]]
-                           [--cell <cell>]
+    usage: craton device-list [--detail] [--limit <limit>]
+                              [--sort-key <field>] [--sort-dir <direction>]
+                              [--fields <field> [<field> ...]]
+                              [--cell <cell>]
 
 **Optional arguments:**
 
-``-c <cell>, --cell <cell>``
- UUID of the cell that contains the desired list of devices.
+.. option:: -c <cell>, --cell <cell>
 
-``--detail``
- Show detailed information about the device.
+    UUID of the cell that contains the desired list of devices.
 
-``--limit <limit>``
- Maximum number of devices to return per request, 0 for no limit. Default is the maximum number used by the Craton API Service.
+.. option:: --detail
 
-``--sort-key <field>``
- Device field that will be used for sorting.
+    Show detailed information about the device.
 
-``--sort-dir <direction>``
- Sort direction: “asc” (the default) or “desc”.
+.. option:: --limit <limit>
 
-``--fields <field> [<field> ...]``
- One or more device fields. Only these fields will be fetched from the server. Can not be used when ‘-- detail’ is specified.
+    Maximum number of devices to return per request, 0 for no limit. Default
+    is the maximum number used by the Craton API Service.
+
+.. option:: --sort-key <field>
+
+    Device field that will be used for sorting.
+
+.. option:: --sort-dir <direction>
+
+    Sort direction: “asc” (the default) or “desc”.
+
+.. option:: --fields <field> [<field> ...]
+
+    One or more device fields. Only these fields will be fetched from the
+    server.  Can not be used when ‘-- detail’ is specified.
+
 
 craton device-show
 ------------------
+
+.. program:: craton device-show
+
 Show detailed information about a device.
+
 ::
 
- usage: craton device-show <device>
+    usage: craton device-show <device>
 
 **Positional arguments:**
 
-``<device>``
- UUID of the device.
+.. option:: device
+
+    UUID of the device.
+
 
 craton device-update
 --------------------
+
+.. program:: craton device-update
+
 Update information about a device.
+
 ::
 
- usage: craton device-update <device> [-n <name>]
+    usage: craton device-update <device> [-n <name>]
 
 **Positional arguments:**
 
-``<device>``
- UUID of the device.
+.. option:: device
+
+    UUID of the device.
 
 **Optional arguments:**
 
-``-n <name>, --name <name>``
- New name for the device.
+.. option:: -n <name>, --name <name>
+
+    New name for the device.
+
 
 craton host-create
 ------------------
+
+.. program:: craton host-create
+
 Create a new host.
+
 ::
 
- usage: craton host-create [-n <name>] [-t <type>] [-a <active>] [-u <uuid>] [-p <project>] [-r <region>] [-c <cell>] [--note <note>] [--access_secret <access_secret>] [-i <ip_address>]
+    usage: craton host-create [-n <name>]
+                            [-t <type>]
+                            [-a <active>]
+                            [-u <uuid>]
+                            [-p <project>]
+                            [-r <region>]
+                            [-c <cell>]
+                            [--note <note>]
+                            [--access_secret <access_secret>]
+                            [-i <ip_address>]
 
 **Optional arguments:**
 
-``-n <name>, --name <name>``
- Name of the host.
+.. option:: -n <name>, --name <name>
 
-``-t <type>, --type <type>``
- Type of host.
+    Name of the host.
 
-``-a <active>, --active <active>``
- Active or inactive state for a host: ‘true’ or ‘false’.
+.. option:: -t <type>, --type <type>
 
-``-u <uuid>, --uuid <uuid>``
- UUID of the host.
+    Type of host.
 
-``-p <project>, --project <project>, --project_uuid <project>``
- UUID of the project that this host belongs to.
+.. option:: -a <active>, --active <active>
 
-``-r <region>, --region <region>, --region_uuid <region>``
- UUID of the region that this host belongs to.
+    Active or inactive state for a host: ‘true’ or ‘false’.
 
-``-c <cell>, --cell <cell>, --cell_uuid <cell>``
- UUID of the cell that this host belongs to.
+.. option:: -u <uuid>, --uuid <uuid>
 
-``--note <note>``
- Note about the host.
+    UUID of the host.
 
-``--access_secret <access_secret>``
- UUID of the access secret of the host.
+.. option:: -p <project>, --project <project>, --project_uuid <project>
 
-``-i <ip_address>, --ip_address <ip_address>``
- IP Address type of the host.
+    UUID of the project that this host belongs to.
+
+.. option:: -r <region>, --region <region>, --region_uuid <region>
+
+    UUID of the region that this host belongs to.
+
+.. option:: -c <cell>, --cell <cell>, --cell_uuid <cell>
+
+    UUID of the cell that this host belongs to.
+
+.. option:: --note <note>
+
+    Note about the host.
+
+.. option:: --access_secret <access_secret>
+
+    UUID of the access secret of the host.
+
+.. option:: -i <ip_address>, --ip_address <ip_address>
+
+    IP Address type of the host.
+
 
 craton host-delete
 ------------------
+
+.. program:: craton host-delete
+
 Delete a host.
+
 ::
 
- usage: craton host-delete <host>
+    usage: craton host-delete <host>
 
 **Positional arguments:**
 
-``<host>``
- UUID of the host.
+.. option:: host
+
+    UUID of the host.
+
 
 craton host-list
 ----------------
+
+.. program:: craton host-list
+
 List the hosts.
+
 ::
 
- usage: craton host-list [--detail] [--limit <limit>]
+    usage: craton host-list [--detail] [--limit <limit>]
                          [--sort-key <field>] [--sort-dir <direction>]
                          [--fields <field> [<field> ...]]
                          [--cell <cell>]
 
 **Optional arguments:**
 
-``-c <cell>, --cell <cell>``
- UUID of the cell that contains the desired list of hosts.
+.. option:: -c <cell>, --cell <cell>
 
-``--detail``
- Show detailed information about the host.
+    UUID of the cell that contains the desired list of hosts.
 
-``--limit <limit>``
- Maximum number of hosts to return per request, 0 for no limit. Default is the maximum number used by the Craton API Service.
+.. option:: --detail
 
-``--sort-key <field>``
- Host field that will be used for sorting.
+    Show detailed information about the host.
 
-``--sort-dir <direction>``
- Sort direction: “asc” (the default) or “desc”.
+.. option:: --limit <limit>
 
-``--fields <field> [<field> ...]``
- One or more host fields. Only these fields will be fetched from the server. Can not be used when ‘-- detail’ is specified.
+    Maximum number of hosts to return per request, 0 for no limit. Default is
+    the maximum number used by the Craton API Service.
+
+.. option:: --sort-key <field>
+
+    Host field that will be used for sorting.
+
+.. option:: --sort-dir <direction>
+
+    Sort direction: “asc” (the default) or “desc”.
+
+.. option:: --fields <field> [<field> ...]
+
+    One or more host fields. Only these fields will be fetched from the
+    server.  Can not be used when ‘-- detail’ is specified.
+
 
 craton host-show
 ----------------
+
+.. program:: craton host-show
+
 Show detailed information about a host.
+
 ::
 
- usage: craton host-show <host>
+    usage: craton host-show <host>
 
 **Positional arguments:**
 
-``<host>``
- UUID of the host.
+.. option:: host
+
+    UUID of the host.
+
 
 craton host-update
 ------------------
+
+.. program:: craton host-update
+
 Update information about a host.
+
 ::
 
- usage: craton host-update <host> [-n <name>]
+    usage: craton host-update <host> [-n <name>]
 
 **Positional arguments:**
 
-``<host>``
- UUID of the host.
+.. option:: host
+
+    UUID of the host.
 
 **Optional arguments:**
 
-``-n <name>, --name <name>``
- New name for the host.
+.. option:: -n <name>, --name <name>
+
+    New name for the host.
 
 
 craton user-list
-------------------------
+----------------
+
+.. program:: craton user-list
+
 List the users in a project.
+
 ::
 
- usage: craton user-list [--detail] [--limit <limit>]
+    usage: craton user-list [--detail] [--limit <limit>]
                          [--sort-key <field>] [--sort-dir <direction>]
                          [--fields <field> [<field> ...]]
 
 **Optional arguments:**
 
-``--detail``
- Show detailed information about the users.
+.. option:: --detail
 
-``--limit <limit>``
- Maximum number of users to return per request, 0 for no limit. Default is the maximum number used by the Craton API Service.
+    Show detailed information about the users.
 
-``--sort-key <field>``
- User field that will be used for sorting.
+.. option:: --limit <limit>
 
-``--sort-dir <direction>``
- Sort direction: “asc” (the default) or “desc”.
+    Maximum number of users to return per request, 0 for no limit. Default is
+    the maximum number used by the Craton API Service.
 
-``--fields <field> [<field> ...]``
- One or more user fields. Only these fields will be fetched from the server. Can not be used when ‘-- detail’ is specified.
+.. option:: --sort-key <field>
+
+    User field that will be used for sorting.
+
+.. option:: --sort-dir <direction>
+
+    Sort direction: “asc” (the default) or “desc”.
+
+.. option:: --fields <field> [<field> ...]
+
+    One or more user fields. Only these fields will be fetched from the
+    server.  Can not be used when ‘-- detail’ is specified.

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -13,6 +13,7 @@ Contents:
 
    readme
    installation
+   cratoncli
    usage
    contributing
 


### PR DESCRIPTION
The program directive (.. program::) gives semantic meaning to the
option directives that follow it (.. option::), e.g.,

    .. program:: craton cell-create

    .. option:: --name <name>

        Description

Is different from

    .. program:: craton cell-delete

    .. option:: --name <name>

        Description

Even though ".. option:: --name <name>" is used twice. The first allows
you to use :option:`craton cell-create --name` which links appropriately
to its documentation.

This also adds the CLI docs to the index so they're findable and
viewable.