### PR TITLE
read the docs setup, plus fix broken links in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -19,8 +19,8 @@ For more information, please refer to the following project resources:
 * **Blueprints:** https://blueprints.launchpad.net/craton
 * **Bugs:** https://waffle.io/rackerlabs/craton
 
-We plan to move these links to OpenStack infrastructure once Craton
-becomes an OpenStack project.
+TODO(all) We plan to move these links to OpenStack infrastructure once
+Craton becomes an OpenStack project.
 
 For information on how to contribute to Craton, please see the
 contents of the `CONTRIBUTING.rst file <CONTRIBUTING.rst>`_.

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -38,7 +38,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'craton'
-copyright = u'2013, OpenStack Foundation'
+copyright = u'2016, Rackspace, Intel'
 
 # If true, '()' will be appended to :func: etc. cross-reference text.
 add_function_parentheses = True

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -16,15 +16,17 @@ import os
 import sys
 
 sys.path.insert(0, os.path.abspath('../..'))
+on_read_the_docs = os.environ.get('READTHEDOCS') == 'True'
+
 # -- General configuration ----------------------------------------------------
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
 extensions = [
     'sphinx.ext.autodoc',
-    #'sphinx.ext.intersphinx',
-    'oslosphinx'
 ]
+if not on_read_the_docs:
+    extensions.append('oslosphinx')
 
 # autodoc generation is a bit aggressive and a nuisance when doing heavy
 # text edit cycles.

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -39,7 +39,11 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = u'craton'
+project = u'Craton'
+
+# All contributors should update with their employers (if applicable);
+# for individuals working on Craton, we can add Craton Developers when
+# that becomes relevant.
 copyright = u'2016, Rackspace, Intel'
 
 # If true, '()' will be appended to :func: etc. cross-reference text.

--- a/requirements.readthedocs.txt
+++ b/requirements.readthedocs.txt
@@ -1,2 +1,0 @@
-# Support being built on readthedocs.org
-oslosphinx!=3.4.0,>=2.5.0 # Apache-2.0

--- a/requirements.readthedocs.txt
+++ b/requirements.readthedocs.txt
@@ -1,0 +1,2 @@
+# Support being built on readthedocs.org
+oslosphinx!=3.4.0,>=2.5.0 # Apache-2.0


### PR DESCRIPTION
Let's not have broken links in `README.rst` - once we actually move to OpenStack infra, we can atomically update this in one commit against master with a merged PR.

Because we now have some docs, it's useful to build transitionally with readthedocs.org, which is enabled here as well. This can be seen in this build: http://craton.readthedocs.io/en/craton-read-the-docs-setup/ Currently http://craton.readthedocs.org points at this build, however, we can update to master once this PR is merged.

Closes #64