### PR TITLE
Always return created obj back on REST calls

### DIFF
--- a/craton/inventory/api/v1/cells.py
+++ b/craton/inventory/api/v1/cells.py
@@ -65,12 +65,13 @@ class Cells(base.Resource):
         """Create a new cell."""
         context = request.environ.get('context')
         try:
-            dbapi.cells_create(context, g.json)
+            cell_obj = dbapi.cells_create(context, g.json)
         except Exception as err:
             LOG.error("Error during cell create: %s" % err)
             return self.error_response(500, 'Unknown Error')
 
-        return None, 200, None
+        cell = jsonutils.to_primitive(cell_obj)
+        return cell, 200, None
 
     def put(self, id):
         """Update existing cell."""

--- a/craton/inventory/api/v1/hosts.py
+++ b/craton/inventory/api/v1/hosts.py
@@ -63,12 +63,13 @@ class Hosts(base.Resource):
         """Create a new host."""
         context = request.environ.get('context')
         try:
-            dbapi.hosts_create(context, g.json)
+            host_obj = dbapi.hosts_create(context, g.json)
         except Exception as err:
             LOG.error("Error during host create: %s" % err)
             return self.error_response(500, 'Unknown Error')
 
-        return None, 200, None
+        host = jsonutils.to_primitive(host_obj)
+        return host, 200, None
 
 
 class HostById(base.Resource):
@@ -111,11 +112,9 @@ class HostsData(base.Resource):
         Update existing host data, or create if it does
         not exist.
         """
-        data_keys = request.form.keys()
-        data = dict((key, request.form.getlist(key)[0]) for key in data_keys)
         context = request.environ.get('context')
         try:
-            dbapi.hosts_data_update(context, id, data)
+            dbapi.hosts_data_update(context, id, request.json)
         except Exception as err:
             LOG.error("Error during host data update: %s" % err)
             return self.error_response(500, 'Unknown Error')
@@ -127,11 +126,9 @@ class HostsData(base.Resource):
         # NOTE(sulo): this is not that great. Find a better way to do this.
         # We can pass multiple keys suchs as key1=one key2=two etc. but not
         # the best way to do this.
-        data_keys = request.form.keys()
-        data = dict((key, request.form.getlist(key)[0]) for key in data_keys)
         context = request.environ.get('context')
         try:
-            dbapi.hosts_data_delete(context, id, data)
+            dbapi.hosts_data_delete(context, id, request.json)
         except Exception as err:
             LOG.error("Error during host delete: %s" % err)
             return self.error_response(500, 'Unknown Error')

--- a/craton/inventory/api/v1/regions.py
+++ b/craton/inventory/api/v1/regions.py
@@ -65,12 +65,13 @@ class Regions(base.Resource):
         """Create a new region."""
         context = request.environ.get('context')
         try:
-            dbapi.regions_create(context, g.json)
+            region_obj = dbapi.regions_create(context, g.json)
         except Exception as err:
             LOG.error("Error during region create: %s" % err)
             return self.error_response(500, 'Unknown Error')
 
-        return None, 200, None
+        region = jsonutils.to_primitive(region_obj)
+        return region, 200, None
 
     def put(self, id):
         """Update existing region."""

--- a/craton/inventory/api/v1/schemas.py
+++ b/craton/inventory/api/v1/schemas.py
@@ -58,9 +58,9 @@ DefinitionsRegion = {'discriminator': 'name',
                          'name': {
                              'type': 'string',
                              'description': 'Region Name.'},
-                         'region_uuid': {
+                         'project_id': {
                              'type': 'string',
-                             'description': 'UUID of the region.'},
+                             'description': 'ID of the project'},
                          'cells': {
                              'items': DefinitionsCell,
                              'type': 'array',
@@ -165,7 +165,7 @@ filters = {
          404: {'headers': None, 'schema': None},
          405: {'headers': None, 'schema': None}},
     ('regions', 'POST'):
-        {200: {'headers': None, 'schema': None},
+        {200: {'headers': None, 'schema': DefinitionsRegion},
          400: {'headers': None, 'schema': None},
          405: {'headers': None, 'schema': None}},
     ('regions', 'GET'):
@@ -184,7 +184,7 @@ filters = {
             404: {'headers': None, 'schema': None},
             405: {'headers': None, 'schema': None}},
     ('hosts', 'POST'):
-        {200: {'headers': None, 'schema': None},
+        {200: {'headers': None, 'schema': DefinitionsHost},
          400: {'headers': None, 'schema': None},
          405: {'headers': None, 'schema': None}},
     ('hosts', 'GET'):
@@ -204,7 +204,7 @@ filters = {
          404: {'headers': None, 'schema': None},
          405: {'headers': None, 'schema': None}},
     ('cells', 'POST'):
-        {200: {'headers': None, 'schema': None},
+        {200: {'headers': None, 'schema': DefinitionsCell},
          400: {'headers': None, 'schema': None},
          405: {'headers': None, 'schema': None}},
     ('cells', 'GET'):

--- a/craton/inventory/tests/unit/test_api.py
+++ b/craton/inventory/tests/unit/test_api.py
@@ -70,6 +70,16 @@ class APIV1CellsTest(APIV1Test):
         self.assertEqual(200, resp.status_code)
 
     @mock.patch.object(dbapi, 'cells_create')
+    def test_create_cell_returns_cell_obj(self, mock_cell):
+        return_value = {'name': 'cell1', 'region_id': 1,
+                        'project_id': 1, 'id': 1}
+        mock_cell.return_value = return_value
+        data = {'name': 'cell1', 'region_id': 1, 'project_id': "1"}
+        resp = self.post('v1/cells', data=data)
+        self.assertEqual(200, resp.status_code)
+        self.assertEqual(return_value, resp.json)
+
+    @mock.patch.object(dbapi, 'cells_create')
     def test_create_cell_fails_with_invalid_data(self, mock_cell):
         mock_cell.return_value = None
         # data is missing required cell name
@@ -111,6 +121,15 @@ class APIV1RegionsTest(APIV1Test):
         self.assertEqual(200, resp.status_code)
 
     @mock.patch.object(dbapi, 'regions_create')
+    def test_create_region_returns_region_obj(self, mock_region):
+        return_value = {'name': 'region1', 'project_id': '1', 'id': 1}
+        mock_region.return_value = return_value
+        data = {'name': 'region1', 'project_id': '1'}
+        resp = self.post('v1/regions', data=data)
+        self.assertEqual(200, resp.status_code)
+        self.assertEqual(return_value, resp.json)
+
+    @mock.patch.object(dbapi, 'regions_create')
     def test_post_region_with_invalid_data_fails(self, mock_region):
         mock_region.return_value = None
         data = {'project_id': '1'}
@@ -145,3 +164,14 @@ class APIV1HostsTest(APIV1Test):
                 'ip_address': '10.0.0.1'}
         resp = self.post('/v1/hosts', data=data)
         self.assertEqual(200, resp.status_code)
+
+    @mock.patch.object(dbapi, 'hosts_create')
+    def test_create_host_returns_host_obj(self, mock_host):
+        return_value = {'name': 'www.host1.com', 'region_id': '1',
+                        'project_id': '1', 'ip_address': '10.0.0.1', 'id': 1}
+        mock_host.return_value = return_value
+        data = {'name': 'www.host1.com', 'region_id': '1', 'project_id': '1',
+                'ip_address': '10.0.0.1'}
+        resp = self.post('v1/hosts', data=data)
+        self.assertEqual(200, resp.status_code)
+        self.assertEqual(return_value, resp.json)


### PR DESCRIPTION
- we were not returning the created objects back on
CREATE calls on rest api. This patch fixes that.